### PR TITLE
AUTO-142 -- linting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,16 +25,12 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RslidarPacket.msg"
   DEPENDENCIES builtin_interfaces std_msgs
- )
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
-  # the following line skips the linter which checks for copyrights
-  # uncomment the line when a copyright and license is not present in all source files
-  #set(ament_cmake_copyright_FOUND TRUE)
-  # the following line skips cpplint (only works in a git repo)
-  # uncomment the line when this package is not in a git repo
-  #set(ament_cmake_cpplint_FOUND TRUE)
+  # skip copyright and license
+  set(ament_cmake_copyright_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
 endif()
 

--- a/ros1/CMakeLists.txt
+++ b/ros1/CMakeLists.txt
@@ -23,19 +23,19 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   sensor_msgs
   message_generation
-  )
+)
 
 add_message_files(FILES
   RslidarPacket.msg
-  )
+)
 
-generate_messages(DEPENDENCIES 
+generate_messages(DEPENDENCIES
   std_msgs
   sensor_msgs
-  )
+)
 
-catkin_package(CATKIN_DEPENDS 
-  std_msgs 
+catkin_package(CATKIN_DEPENDS
+  std_msgs
   sensor_msgs
   message_runtime
-  )
+)

--- a/ros2/CMakeLists.txt
+++ b/ros2/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(rosidl_default_generators REQUIRED)
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/RslidarPacket.msg"
   DEPENDENCIES builtin_interfaces std_msgs
- )
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)


### PR DESCRIPTION
This PR simply makes the linter pass. I also did the lining for the example `CMakeFiles.txt`s simply because `ament_cmake_lint` doesn't yet listen to file excludes (I think). `colcon build && colcon test` should pass without test failures like [here](https://github.com/botsandus/auto/actions/runs/3551256412/jobs/5965404986#step:8:762). 

(also added it upstream https://github.com/RoboSense-LiDAR/rslidar_msg/pull/2)

